### PR TITLE
Update DESCRIPTION Imports entry for `{sf}`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Imports:
     mapdata (>= 2.3.0),
     maps (>= 3.3.0),
     rlang (>= 0.4.0),
-    sf (>= 1.0.12),
+    sf (>= 1.0-12),
     stats,
     stringi (>= 1.7.6),
     utils


### PR DESCRIPTION
`R CMD check` failed for Ubuntu due the inability to resolve the dependency on the `{sf}` package. On closer examination,  I noticed that the package version on CRAN is dash-separated (x.x-x), while in the DESCRIPTION file is is dot-separated. This change is being made to see whether it will fix the problem with `check`.