### PR TITLE
Fix: Return output of `lgas` object as a sorted list

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Restore R package cache
         if: runner.os != 'Windows'
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Description: A set of convenience functions as well as geographical/political
 License: GPL-3
 LazyData: TRUE
 Encoding: UTF-8
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 VignetteBuilder: knitr
 RdMacros: lifecycle
 URL: https://docs.ropensci.org/naijR/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: naijR
 Type: Package
 Title: Operations to Ease Data Analyses Specific to Nigeria
-Version: 0.6.1
+Version: 0.6.2
 Depends: R (>= 3.6)
 Imports:
     RColorBrewer (>= 1.1.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,103 +1,133 @@
+# naijR 0.6.2
+- Return LGA output after object creation as sorted values. This is to enhance the user experience.
+
 # naijR 0.6.1
-* Added more function examples and other documentation improvements.
-* Increased compression for internal data.
-* Reflect new home on rOpenSci software repository.
+
+-   Added more function examples and other documentation improvements.
+-   Increased compression for internal data.
+-   Reflect new home on rOpenSci software repository.
 
 # naijR 0.6.0
+
 ## New Features:
-* Added a new dataset `states_nigeria` for the States of Nigeria.
-* Migrated from RGDAL-based spatial data; the `{sf}` package is now the main dependency.
-* `map_ng` gained a newly documented argument `plot`, which hitherto was passed internally to `maps::map()` via `...`.
-* Added a new function `disambiguate_lga`, which takes a single-element `lgas` object for handling the names of Local Government Areas that are shared between separate States. This function enables the (re)setting of the `State` attribute of such objects; this can be done interactively, where the replicated States' names are presented for selection by users.
+
+-   Added a new dataset `states_nigeria` for the States of Nigeria.
+-   Migrated from RGDAL-based spatial data; the `{sf}` package is now the main dependency.
+-   `map_ng` gained a newly documented argument `plot`, which hitherto was passed internally to `maps::map()` via `...`.
+-   Added a new function `disambiguate_lga`, which takes a single-element `lgas` object for handling the names of Local Government Areas that are shared between separate States. This function enables the (re)setting of the `State` attribute of such objects; this can be done interactively, where the replicated States' names are presented for selection by users.
 
 ## Fixes:
-* Improved on the accuracy of LGA naming in the light of spelling mistakes discovered in the earlier reference document.
-* Unwanted display of dialogs when fixing LGA names on Windows OS was reversed (suggested by Laura DeCicco).
+
+-   Improved on the accuracy of LGA naming in the light of spelling mistakes discovered in the earlier reference document.
+-   Unwanted display of dialogs when fixing LGA names on Windows OS was reversed (suggested by Laura DeCicco).
 
 # naijR 0.5.2
-* Quietened a verbose warning introduced via the soon-to-be-retired spatial data packages.
+
+-   Quietened a verbose warning introduced via the soon-to-be-retired spatial data packages.
 
 # naijR 0.5.1
-* In nested calls with the function `fix_region`, the `lgas` constructor function does not warn if there are spelling mistakes, as this turned out to be a bit confusing when it was used. In earlier versions, warnings persisted even after fixes were applied.
-* In carrying out interactive fixes, particularly of LGA spellings, the more familiar and intuitive native Windows messaging and dialog system is used. Works only on Windows machines; on Linux and MacOs, the usual messaging and interaction occurs at the R console.
-* Control the size of map labels with the `cex` argument (passed on to `maps::map.text` internally, via `...`).
-* Handle instances where the term *Abuja* is used as a State (which technically it is not) and signal a warning to the user.
+
+-   In nested calls with the function `fix_region`, the `lgas` constructor function does not warn if there are spelling mistakes, as this turned out to be a bit confusing when it was used. In earlier versions, warnings persisted even after fixes were applied.
+-   In carrying out interactive fixes, particularly of LGA spellings, the more familiar and intuitive native Windows messaging and dialog system is used. Works only on Windows machines; on Linux and MacOs, the usual messaging and interaction occurs at the R console.
+-   Control the size of map labels with the `cex` argument (passed on to `maps::map.text` internally, via `...`).
+-   Handle instances where the term *Abuja* is used as a State (which technically it is not) and signal a warning to the user.
 
 # naijR 0.5.0
+
 ## New features:
-* New methods for `?InternalGenerics` were introduced e.g. for `c()`, `[`, `[[`, `na.exclude`, etc.
+
+-   New methods for `?InternalGenerics` were introduced e.g. for `c()`, `[`, `[[`, `na.exclude`, etc.
 
 ## Enhancements:
-* Effectively handle mobile numbers that have common separators in them, namely whitespace, '-' or '.'.
-* Repair mobile numbers where poor data entry interchanges zeros (`0`s) with the letter `O` (works for both upper and lower case).
-* Repair of mobile numbers now offers optional information for users.
-* Allow the use of factor input when creating objects of class `regions`.
-* Added a new argument `legend.text` for `map_ng` using an idiom that is similar to the one used in `base::barplot`, thanks to observations made by @VictoriaLatham in issue #27.
-* Simplified the creation of choropleth maps with 2-column data frames; one of the columns is to be a vector of valid States or Local Government Areas, and the other a factor or something coercible to one. 
+
+-   Effectively handle mobile numbers that have common separators in them, namely whitespace, '-' or '.'.
+-   Repair mobile numbers where poor data entry interchanges zeros (`0`s) with the letter `O` (works for both upper and lower case).
+-   Repair of mobile numbers now offers optional information for users.
+-   Allow the use of factor input when creating objects of class `regions`.
+-   Added a new argument `legend.text` for `map_ng` using an idiom that is similar to the one used in `base::barplot`, thanks to observations made by @VictoriaLatham in issue #27.
+-   Simplified the creation of choropleth maps with 2-column data frames; one of the columns is to be a vector of valid States or Local Government Areas, and the other a factor or something coercible to one.
 
 ## Bug fixes:
-* `map_ng` accepted arguments that were not `data.frame`s leading to unwieldy errors. It is now made sure to fail early in such cases
+
+-   `map_ng` accepted arguments that were not `data.frame`s leading to unwieldy errors. It is now made sure to fail early in such cases
 
 ## Deprecated:
-* Arguments of `map_ng` - `leg.x`, `leg.y`, and `leg.orient` were marked for deprecation in the next minor release.
+
+-   Arguments of `map_ng` - `leg.x`, `leg.y`, and `leg.orient` were marked for deprecation in the next minor release.
 
 # naijR 0.4.4
+
 ## Bug fix:
-* `fix_mobile` fails unexpectedly when only `NA` is supplied as argument. This causes practical problems when, for example, it encounters a column with only missing values.
+
+-   `fix_mobile` fails unexpectedly when only `NA` is supplied as argument. This causes practical problems when, for example, it encounters a column with only missing values.
 
 # naijR 0.4.3
-* Addressed a build problem related to CRAN submission.
+
+-   Addressed a build problem related to CRAN submission.
 
 # naijR 0.4.2
-* Improved type checking for mapping functionality and better fidelity.
+
+-   Improved type checking for mapping functionality and better fidelity.
 
 # naijR 0.4.1
-* Enable the exclusion of selected States from a choropleth map (#27).
-* Cleaner output for `states` and `lgas` objects.
+
+-   Enable the exclusion of selected States from a choropleth map (#27).
+-   Cleaner output for `states` and `lgas` objects.
 
 # naijR 0.4.0
-* Introduce the ability to 'manually' fix names of States or LGAs.
-* Update the documentation with a new vignette.
+
+-   Introduce the ability to 'manually' fix names of States or LGAs.
+-   Update the documentation with a new vignette.
 
 # naijR 0.3.4
-* Fixed package-wide misuse of the word _Nasarawa_.
+
+-   Fixed package-wide misuse of the word *Nasarawa*.
 
 # naijR 0.3.3
-* Fixed repetitions in the output when multiple LGAs' spellings are corrected.
+
+-   Fixed repetitions in the output when multiple LGAs' spellings are corrected.
 
 # naijR 0.3.2
-* Improved on print methods
+
+-   Improved on print methods
 
 # naijR 0.3.1
-* Fixed a bug that affected the proper rendering of LGA-level maps for some of the States. The approach used was to simply filter the entire data when requiring a State map, so as to reduce name clashes that occurred from synonyms amongst some of the LGAs and/or States.
-* Enabled the fine-tuning of creation of `lgas` objects in the event that the argument provided is the name of an LGA that is synonymous with it's State (argument `strict`).
+
+-   Fixed a bug that affected the proper rendering of LGA-level maps for some of the States. The approach used was to simply filter the entire data when requiring a State map, so as to reduce name clashes that occurred from synonyms amongst some of the LGAs and/or States.
+-   Enabled the fine-tuning of creation of `lgas` objects in the event that the argument provided is the name of an LGA that is synonymous with it's State (argument `strict`).
 
 # naijR 0.3.0
-* Provide new methods for the S3 generics `head` and `tail` to work with objects that inherit from class `regions`.
-* The S3 constructors `states` and `lgas` gain a logical argument `warn` to control whether or not they issue a warning when an input string does not contain an actual State/LGA.
-* General improvement of the formatting of output to enhance the user experience.
-* Fixed a bug that prevented the loading of LGAs from the internal data when the package is not attached to the search path i.e. invocation with `naijR::lgas()` was producing an error.
+
+-   Provide new methods for the S3 generics `head` and `tail` to work with objects that inherit from class `regions`.
+-   The S3 constructors `states` and `lgas` gain a logical argument `warn` to control whether or not they issue a warning when an input string does not contain an actual State/LGA.
+-   General improvement of the formatting of output to enhance the user experience.
+-   Fixed a bug that prevented the loading of LGAs from the internal data when the package is not attached to the search path i.e. invocation with `naijR::lgas()` was producing an error.
 
 # naijR 0.2.2
-* Export S3 generic `fix_region`.
+
+-   Export S3 generic `fix_region`.
 
 # naijR 0.2.1
-* Fixed incorrect URLs, as noted by CRAN
-* Edits to output message
+
+-   Fixed incorrect URLs, as noted by CRAN
+-   Edits to output message
 
 # naijR 0.2.0
-* Added a new function `is_lga`, which checks an object for Local Government Areas.
-* Ignore, with a warning, the check for `is_state` when the object checked is not of type `character`.
-* Draw maps up to LGA level
+
+-   Added a new function `is_lga`, which checks an object for Local Government Areas.
+-   Ignore, with a warning, the check for `is_state` when the object checked is not of type `character`.
+-   Draw maps up to LGA level
 
 # naijR 0.1.5
-* Built new package website.
+
+-   Built new package website.
 
 # naijR 0.1.4
-* Suppress deprecation warning for `is_state` when it is called internally by package function; displayed only when function is called directly.
+
+-   Suppress deprecation warning for `is_state` when it is called internally by package function; displayed only when function is called directly.
 
 # naijR 0.1.3
-* Added a `NEWS.md` file to track changes to the package.
-* Recognise abbreviations of 'Federal Capital Territory' i.e. FCT.
-* Disable error-check on character type for `is_state` so it can be used more effectively for functional programming constructs.
 
+-   Added a `NEWS.md` file to track changes to the package.
+-   Recognise abbreviations of 'Federal Capital Territory' i.e. FCT.
+-   Disable error-check on character type for `is_state` so it can be used more effectively for functional programming constructs.

--- a/R/fixreg.R
+++ b/R/fixreg.R
@@ -4,9 +4,9 @@
 #
 # Copyright (C) 2019-2023 Victor Ordu.
 
-#' Fix Misspelling of Adminstrative Regions
+#' Fix Misspelling of Administrative Regions
 #' 
-#' Correct any misspelt names of administrative regions e.g. States and LGAs.
+#' Correct any misspelled names of administrative regions e.g. States and LGAs.
 #' 
 #' @details \code{fix_region} will look through a character vector and try to 
 #' determine if State or LGA names have been wrongly entered. This presupposes
@@ -17,16 +17,16 @@
 #' update the spelling.
 #' 
 #' @note When passed a character vector of length \code{1L}, in the case of a
-#' misspelt LGA, the function signals an error; the presumption is that a fix
+#' misspelled LGA, the function signals an error; the presumption is that a fix
 #' can readily be applied interactively. When all the items provided are 
-#' misspelt, nothing happens, but the user is advised to use the appropriate
+#' misspelled, nothing happens, but the user is advised to use the appropriate
 #' constructor function so as to improve the accuracy of the repairs. When
-#' there is a mix of misspelt and properly spelt LGAs, other functionalities
+#' there is a mix of misspelled and properly spelled LGAs, other avenues
 #' for fixing the mistakes are available via mode \code{interactive}.
 #' 
 #' @param x An S3 object of class \code{states} or \code{lgas}. For 
 #' \code{fix_region.default}, a character vector (or an object coercible to 
-#' one) can be passed but only that for 'States' will be interpretable.
+#' one) can be passed but only that for 'States' can be interpreted.
 #' @param ... Arguments passed to methods.
 #' 
 #' @return The transformed object. If all names are correct, the object is
@@ -67,7 +67,7 @@ fix_region.states <- function(x, ...)
     ss <- sub(fullFCT, abbrFCT, ss)
   
   x <- .fix_region_internal(x, ss)
-  nofix <- attr(x, "misspelt")
+  nofix <- attr(x, "misspelled")
   
   if (length(nofix)) {
     commasep <- paste(nofix, collapse = ", ")
@@ -174,13 +174,13 @@ fix_region.lgas <-
   ## For the LGAs case, the expectation is that in a vector with more than
   ## one element, if any of the elements passess the test of being an LGA
   ## then one can safely assume that the other element(s) that fail the test
-  ## did so because they were misspelt. An automatic fix will then be attempted.
+  ## did so because they were misspelled. An automatic fix will then be attempted.
   ## First, ignore synonymous elements i.e. those that are both States/LGAs.
   nonSynonyms <- x[!x %in% lgas_like_states()]
   
   region <- if (any(is_lga(nonSynonyms)))    # We use 'any()' because we want
     lgas(x, warn = FALSE)                    # to allow creation of temporary,
-  else if (any(is_state(nonSynonyms)))       # even with misspelt elements
+  else if (any(is_state(nonSynonyms)))       # even with misspelled elements
     states(x, warn = FALSE)
   else
     cli_abort(
@@ -197,8 +197,8 @@ fix_region.lgas <-
 
 #' @rdname fix_region
 #' 
-#' @param wrong The misspelt element(s) of \code{x}.
-#' @param correct The correction that is to be applied to the misspelt 
+#' @param wrong The misspelled element(s) of \code{x}.
+#' @param correct The correction that is to be applied to the misspelled 
 #' element(s)
 #' 
 #' @examples

--- a/R/fixreg.R
+++ b/R/fixreg.R
@@ -67,7 +67,7 @@ fix_region.states <- function(x, ...)
     ss <- sub(fullFCT, abbrFCT, ss)
   
   x <- .fix_region_internal(x, ss)
-  nofix <- attr(x, "misspelled")
+  nofix <- attr(x, "misspelt")
   
   if (length(nofix)) {
     commasep <- paste(nofix, collapse = ", ")

--- a/R/regions.R
+++ b/R/regions.R
@@ -263,7 +263,7 @@ lgas <- function(region = NA_character_, strict = FALSE, warn = TRUE) {
     }
   }
 
-  if (length(region) == 1L && is.na(region))
+  if (length(region) == 1L && is.na(region))  # TODO: Huh?
     return(new_lgas(lgas_nigeria$lga))
 
   lst <- region
@@ -313,7 +313,7 @@ lgas <- function(region = NA_character_, strict = FALSE, warn = TRUE) {
 # Low-level S3 constructor for lgas object
 new_lgas <- function(x)
 {
-  structure(x, class = c("lgas", "regions", class(x)))
+  structure(sort(x), class = c("lgas", "regions", class(x)))
 }
 
 

--- a/R/regions.R
+++ b/R/regions.R
@@ -251,6 +251,10 @@ lgas <- function(region = NA_character_, strict = FALSE, warn = TRUE) {
 
   if (!is.character(region))
     cli_abort("Expected an object of type 'character'")
+  
+  # if ((!is.na(region) && all(region == "")) || 
+  #     (all(is.na(region)) && length(region) > 1))
+  #   cli_abort("Illegal use of empty string/missing character values")
 
   if (strict) {
     not.synonymous <- !(region %in% lgas_like_states())
@@ -263,8 +267,10 @@ lgas <- function(region = NA_character_, strict = FALSE, warn = TRUE) {
     }
   }
 
-  if (length(region) == 1L && is.na(region))  # TODO: Huh?
-    return(new_lgas(lgas_nigeria$lga))
+  if (length(region) == 1L && is.na(region)) {
+    lgvec <- sort(lgas_nigeria$lga)
+    return(new_lgas(lgvec))
+  }
 
   lst <- region
 
@@ -304,7 +310,15 @@ lgas <- function(region = NA_character_, strict = FALSE, warn = TRUE) {
   # have a State attribute that lists the States and this should
   # apply to lgas objects that have just one element so that
   # there is no confusion.
-  structure(new_lgas(lst), State = region)
+  if (inherits(lst, "list"))
+    lst <- lapply(lst, sort)
+  
+  if (inherits(lst, "character"))
+    lst <- sort(lst)
+  
+  obj <- new_lgas(lst)
+  attr(obj, which = "State") <- region
+  obj
 }
 
 
@@ -313,7 +327,7 @@ lgas <- function(region = NA_character_, strict = FALSE, warn = TRUE) {
 # Low-level S3 constructor for lgas object
 new_lgas <- function(x)
 {
-  structure(sort(x), class = c("lgas", "regions", class(x)))
+  structure(x, class = c("lgas", "regions", class(x)))
 }
 
 

--- a/man/fix_region.Rd
+++ b/man/fix_region.Rd
@@ -6,7 +6,7 @@
 \alias{fix_region.lgas}
 \alias{fix_region.default}
 \alias{fix_region_manual}
-\title{Fix Misspelling of Adminstrative Regions}
+\title{Fix Misspelling of Administrative Regions}
 \usage{
 fix_region(x, ...)
 
@@ -21,7 +21,7 @@ fix_region_manual(x, wrong, correct)
 \arguments{
 \item{x}{An S3 object of class \code{states} or \code{lgas}. For 
 \code{fix_region.default}, a character vector (or an object coercible to 
-one) can be passed but only that for 'States' will be interpretable.}
+one) can be passed but only that for 'States' can be interpreted.}
 
 \item{...}{Arguments passed to methods.}
 
@@ -33,9 +33,9 @@ options.}
 
 \item{graphic}{Whether to make use of native GUI elements (on Windows only).}
 
-\item{wrong}{The misspelt element(s) of \code{x}.}
+\item{wrong}{The misspelled element(s) of \code{x}.}
 
-\item{correct}{The correction that is to be applied to the misspelt 
+\item{correct}{The correction that is to be applied to the misspelled 
 element(s)}
 }
 \value{
@@ -43,7 +43,7 @@ The transformed object. If all names are correct, the object is
 returned unchanged.
 }
 \description{
-Correct any misspelt names of administrative regions e.g. States and LGAs.
+Correct any misspelled names of administrative regions e.g. States and LGAs.
 }
 \details{
 \code{fix_region} will look through a character vector and try to 
@@ -56,11 +56,11 @@ update the spelling.
 }
 \note{
 When passed a character vector of length \code{1L}, in the case of a
-misspelt LGA, the function signals an error; the presumption is that a fix
+misspelled LGA, the function signals an error; the presumption is that a fix
 can readily be applied interactively. When all the items provided are 
-misspelt, nothing happens, but the user is advised to use the appropriate
+misspelled, nothing happens, but the user is advised to use the appropriate
 constructor function so as to improve the accuracy of the repairs. When
-there is a mix of misspelt and properly spelt LGAs, other functionalities
+there is a mix of misspelled and properly spelled LGAs, other avenues
 for fixing the mistakes are available via mode \code{interactive}.
 }
 \examples{

--- a/man/naijR.Rd
+++ b/man/naijR.Rd
@@ -14,6 +14,14 @@ management of data sets of interest including data cleaning and wrangling,
 as well as making available a number of facilities for geospatial data
 visualisation.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://docs.ropensci.org/naijR/}
+  \item Report bugs at \url{https://github.com/ropensci/naijR/issues}
+}
+
+}
 \author{
 Victor Ordu
 }

--- a/tests/testthat/test-regions.R
+++ b/tests/testthat/test-regions.R
@@ -75,13 +75,18 @@ test_that("FCT can be selectively removed", {
 
 test_that("illegal input is caught early", {
   chErr <- "Expected an object of type 'character'"
-
+  chErr2 <- "Illegal use of empty string/missing character values"
+  
   expect_error(lgas("Saarland"))
   expect_error(lgas("Maryland"), "None of the items is a valid LGA")
   expect_error(lgas(888), chErr)
   expect_error(lgas(NULL), chErr)
   expect_error(lgas(TRUE), chErr)
   expect_error(lgas(3.14), chErr)
+  expect_error(lgas(c(NA, NA)), chErr)
+  # expect_error(lgas(c(NA_character_, NA)), chErr2)
+  # expect_error(lgas(""), chErr2)
+  # expect_error(lgas(character(2)), chErr2)
 })
 
 
@@ -98,6 +103,8 @@ test_that("LGAs are returned correctly", {
   expect_length(res2, 2L)
   expect_warning(lgas(c("Oyo West", "Obomo Ngwa")),
                  "One or more items is not an LGA")
+  expect_false(is.unsorted(lgas()))
+  expect_false(is.unsorted(unclass(res)))
 })
 
 test_that("Correct number of LGAs are returned for each State", {
@@ -122,7 +129,7 @@ test_that("State/LGAs synonyms are handled", {
   expect_length(lgas("Bauchi", strict = TRUE), 1L)
 })
 
-test_that("LGA objects' attributes appropriately", {
+test_that("LGA objects' attributes are appropriately formed", {
   expect_identical(attr(lgas("Abia"), "State"), "Abia")
   expect_length(attr(lgas(c("Kebbi", "Jigawa")), "State"), 2L)
   expect_length(attributes(lgas("Rivers")), 2L)


### PR DESCRIPTION
When an `lgas` object is created, the output in the console is unsorted, making it difficult to scan with the naked eye, especially when the list is reasonably long. In this update, that list is arranged alphabetically, which is significantly more user-friendly.